### PR TITLE
Keep record of temporal bots and sessions

### DIFF
--- a/app/controllers/api/bots_controller.rb
+++ b/app/controllers/api/bots_controller.rb
@@ -52,7 +52,7 @@ class Api::BotsController < ApplicationApiController
 
   def preview
     authorize @bot
-    if preview_uuid = PublishBot.preview(@bot, params[:preview_uuid], params[:access_token])
+    if preview_uuid = PublishBot.preview(@bot, params[:access_token])
       render json: {result: :ok, preview_uuid: preview_uuid}
     else
       render json: {result: :error}, status: :bad_request

--- a/app/controllers/api/bots_controller.rb
+++ b/app/controllers/api/bots_controller.rb
@@ -53,7 +53,25 @@ class Api::BotsController < ApplicationApiController
   def preview
     authorize @bot
     if preview_uuid = PublishBot.preview(@bot, params[:access_token])
-      render json: {result: :ok, preview_uuid: preview_uuid}
+      session = current_user.sessions.where(bot: @bot).take
+      session_uuid = session.session_uuid if session
+      render json: {result: :ok, preview_uuid: preview_uuid, session_uuid: session_uuid}
+    else
+      render json: {result: :error}, status: :bad_request
+    end
+  end
+
+  def set_session
+    authorize @bot
+    session = @bot.get_session current_user
+    if session
+      session.session_uuid = params[:session_uuid]
+      session.save!
+    else
+      session = Session.create user: current_user, bot: @bot, session_uuid: params[:session_uuid]
+    end
+    if session && session.session_uuid
+      render json: {result: :ok, session_uuid: session.session_uuid}
     else
       render json: {result: :error}, status: :bad_request
     end

--- a/app/javascript/actions/chat.js
+++ b/app/javascript/actions/chat.js
@@ -33,10 +33,9 @@ export const receiveMessage = (text: string) : T.ChatAction => ({
   timestamp: new Date()
 })
 
-export const _startPreview = (botId: number, previewUuid: ?string, accessToken: string) : T.ChatAction => ({
+export const _startPreview = (botId: number, accessToken: string) : T.ChatAction => ({
   type: START_PREVIEW,
   botId,
-  previewUuid,
   accessToken,
 })
 
@@ -60,25 +59,20 @@ export const updatePreviewIfActive = () => (dispatch : T.Dispatch, getState : T.
 export const startPreview = (bot: T.Bot) => (dispatch : T.Dispatch, getState : T.GetState) => {
   const state = getState()
 
-  let previewUuid = null
   let accessToken = ""
 
   if (state.chat.scope && state.chat.scope.botId == bot.id) {
     // if the bot to preview is the same as before,
-    // better keep the backend bot instance (and the access token)
-    previewUuid = state.chat.previewUuid
+    // better keep the access token
     accessToken = state.chat.accessToken
   } else {
-    // otherwise we need a new backend bot (and new random access token)
-    previewUuid = null
+    // otherwise we need a new random access token
     accessToken = uuidv4()
   }
 
-  dispatch(_startPreview(bot.id, previewUuid, accessToken))
+  dispatch(_startPreview(bot.id, accessToken))
 
-  // TODO if previewing of different bot, we could unpublish the preview of state.chat.previewUuid
-
-  api.previewBot(bot, previewUuid, accessToken)
+  api.previewBot(bot, accessToken)
     .then((result) => {
       dispatch(_startPreviewSuccess(bot.id, result.preview_uuid, accessToken))
     })

--- a/app/javascript/actions/chat.js
+++ b/app/javascript/actions/chat.js
@@ -39,10 +39,11 @@ export const _startPreview = (botId: number, accessToken: string) : T.ChatAction
   accessToken,
 })
 
-export const _startPreviewSuccess = (botId: number, previewUuid: string, accessToken: string) : T.ChatAction => ({
+export const _startPreviewSuccess = (botId: number, previewUuid: string, sessionId: string, accessToken: string) : T.ChatAction => ({
   type: START_PREVIEW_SUCCESS,
   botId,
   previewUuid,
+  sessionId,
   accessToken,
 })
 
@@ -74,7 +75,7 @@ export const startPreview = (bot: T.Bot) => (dispatch : T.Dispatch, getState : T
 
   api.previewBot(bot, accessToken)
     .then((result) => {
-      dispatch(_startPreviewSuccess(bot.id, result.preview_uuid, accessToken))
+      dispatch(_startPreviewSuccess(bot.id, result.preview_uuid, result.session_uuid, accessToken))
     })
     .catch(() => dispatch(pushNotification('Bot preview failed')))
 }

--- a/app/javascript/reducers/chat.js
+++ b/app/javascript/reducers/chat.js
@@ -52,7 +52,7 @@ const startPreview = (state, action) => {
 }
 
 const startPreviewSuccess = (state, action) => {
-  const {botId, previewUuid, accessToken} = action
+  const {botId, previewUuid, sessionId, accessToken} = action
 
   if (state.scope.botId != botId) {
     state = {
@@ -62,12 +62,12 @@ const startPreviewSuccess = (state, action) => {
       pausePreview: false,
       previewUuid,
       accessToken,
-      sessionId: null,
+      sessionId,
     }
   } else {
     // if the bot to preview is the same as before,
     // better keep the messages
-    state = {...state, publishing: false, pausePreview: false, previewUuid, accessToken}
+    state = {...state, publishing: false, pausePreview: false, previewUuid, sessionId, accessToken}
   }
 
   return state

--- a/app/javascript/reducers/chat.js
+++ b/app/javascript/reducers/chat.js
@@ -31,21 +31,21 @@ export default (state : T.ChatState, action : T.ChatAction) : T.ChatState => {
 }
 
 const startPreview = (state, action) => {
-  const {botId, previewUuid, accessToken} = action
+  const {botId, accessToken} = action
 
-  if (state.scope.botId != botId || state.previewUuid != previewUuid) {
+  if (state.scope.botId != botId) {
     state = {
       scope: { botId },
       messages:[],
       publishing: true,
       pausePreview: false,
-      previewUuid,
+      previewUuid: null,
       accessToken,
       connected: false,
       sessionId: null,
     }
   } else {
-    state = {...state, publishing: true, pausePreview: false, previewUuid, accessToken}
+    state = {...state, publishing: true, pausePreview: false, accessToken}
   }
 
   return state
@@ -54,7 +54,7 @@ const startPreview = (state, action) => {
 const startPreviewSuccess = (state, action) => {
   const {botId, previewUuid, accessToken} = action
 
-  if (state.scope.botId != botId || state.previewUuid != previewUuid) {
+  if (state.scope.botId != botId) {
     state = {
       scope: { botId },
       messages:[],

--- a/app/javascript/utils/api.js
+++ b/app/javascript/utils/api.js
@@ -45,8 +45,8 @@ export const unpublishBot = (bot : T.Bot) => {
   return apiDelete(`bots/${bot.id}/publish`)
 }
 
-export const previewBot = (bot : T.Bot, previewUuid : ?string, accessToken : string) => {
-  return apiPostJSON(`bots/${bot.id}/preview`, null, {preview_uuid: previewUuid, access_token: accessToken})
+export const previewBot = (bot : T.Bot, accessToken : string) => {
+  return apiPostJSON(`bots/${bot.id}/preview`, null, {access_token: accessToken})
 }
 
 export const fetchFrontDesk = (botId : number) => {

--- a/app/javascript/utils/api.js
+++ b/app/javascript/utils/api.js
@@ -49,6 +49,10 @@ export const previewBot = (bot : T.Bot, accessToken : string) => {
   return apiPostJSON(`bots/${bot.id}/preview`, null, {access_token: accessToken})
 }
 
+export const setBotSession = (bot : T.Bot, session_uuid : string) => {
+  return apiPostJSON(`bots/${bot.id}/set_session`, null, {session_uuid: session_uuid})
+}
+
 export const fetchFrontDesk = (botId : number) => {
   return apiFetchJSON(`bots/${botId}/front_desk`)
 }

--- a/app/javascript/utils/types.jsx
+++ b/app/javascript/utils/types.jsx
@@ -102,7 +102,6 @@ export type ChatAction = {
 } | {
   type: 'START_PREVIEW',
   botId: number,
-  previewUuid: ?string,
   accessToken: string
 } | {
   type: 'START_PREVIEW_SUCCESS',

--- a/app/javascript/utils/types.jsx
+++ b/app/javascript/utils/types.jsx
@@ -107,6 +107,7 @@ export type ChatAction = {
   type: 'START_PREVIEW_SUCCESS',
   botId: number,
   previewUuid: string,
+  sessionId: string,
   accessToken: string
 } | {
   type: 'PAUSE_PREVIEW',

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -8,6 +8,8 @@ class Bot < ApplicationRecord
   has_many :collaborators, dependent: :destroy
   has_many :invitations, dependent: :destroy
   has_many :collaborating_users, through: :collaborators, source: :user
+  has_many :sessions
+  has_many :users, through: :sessions
 
   validate :has_single_front_desk
 
@@ -106,6 +108,10 @@ class Bot < ApplicationRecord
     else
       []
     end
+  end
+
+  def get_session(user)
+    self.sessions.where(user: user).take
   end
 
   private

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,18 @@
+class Session < ApplicationRecord
+  belongs_to :user
+  belongs_to :bot
+
+  validates :user, presence: true
+  validates :bot, presence: true
+  validate :user_is_at_least_collaborator
+
+  private
+
+  def user_is_at_least_collaborator
+    if user && bot
+      if user != bot.owner and !bot.collaborating_users.include?(user)
+        errors[:user] << "is not a collaborator"
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   has_many :bots, foreign_key: :owner_id, inverse_of: :owner
   has_many :collaborations, class_name: 'Collaborator', dependent: :destroy
   has_many :invitations, foreign_key: :creator_id, dependent: :destroy, inverse_of: :creator
+  has_many :sessions
+  has_many :bots, through: :sessions
 
   def display_name
     name || email

--- a/app/policies/bot_policy.rb
+++ b/app/policies/bot_policy.rb
@@ -33,6 +33,10 @@ class BotPolicy < ApplicationPolicy
     has_access?
   end
 
+  def set_session?
+    has_access?
+  end
+
   def download_manifest?
     can_publish?
   end

--- a/app/services/publish_bot.rb
+++ b/app/services/publish_bot.rb
@@ -17,13 +17,15 @@ class PublishBot
     nil
   end
 
-  def self.preview(bot, preview_uuid, access_token)
-    if preview_uuid.present?
-      Backend.update_bot(preview_uuid, bot.preview_manifest(access_token))
+  def self.preview(bot, access_token)
+    if bot.preview_uuid.present?
+      Backend.update_bot(bot.preview_uuid, bot.preview_manifest(access_token))
     else
-      preview_uuid = Backend.create_bot(bot.preview_manifest(access_token), temp: true)
+      bot.preview_uuid = Backend.create_bot(bot.preview_manifest(access_token), temp: true)
+      bot.save!
     end
-    preview_uuid
+
+    bot.preview_uuid
 
   rescue BackendError => e
     puts "Failed to preview bot: #{e}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
         delete :publish, action: :unpublish
         post :duplicate
         post :preview
+        post :set_session
         get :stats
         get :data
         get :manifest

--- a/db/migrate/20180608153633_add_preview_uuid_to_bots.rb
+++ b/db/migrate/20180608153633_add_preview_uuid_to_bots.rb
@@ -1,0 +1,5 @@
+class AddPreviewUuidToBots < ActiveRecord::Migration[5.1]
+  def change
+    add_column :bots, :preview_uuid, :string
+  end
+end

--- a/db/migrate/20180611185102_create_sessions.rb
+++ b/db/migrate/20180611185102_create_sessions.rb
@@ -1,0 +1,13 @@
+class CreateSessions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :sessions do |t|
+      t.references :user, foreign_key: true
+      t.references :bot, foreign_key: true
+      t.string :session_uuid
+
+      t.timestamps
+    end
+
+    add_index :sessions, [:bot_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180326200002) do
+ActiveRecord::Schema.define(version: 20180608153633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20180326200002) do
     t.datetime "updated_at", null: false
     t.bigint "owner_id"
     t.string "uuid"
+    t.string "preview_uuid"
     t.index ["owner_id"], name: "index_bots_on_owner_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180608153633) do
+ActiveRecord::Schema.define(version: 20180611185102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,6 +104,17 @@ ActiveRecord::Schema.define(version: 20180608153633) do
     t.index ["token"], name: "index_invitations_on_token", unique: true
   end
 
+  create_table "sessions", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "bot_id"
+    t.string "session_uuid"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bot_id", "user_id"], name: "index_sessions_on_bot_id_and_user_id", unique: true
+    t.index ["bot_id"], name: "index_sessions_on_bot_id"
+    t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
   create_table "translations", force: :cascade do |t|
     t.bigint "behaviour_id"
     t.string "key", null: false
@@ -152,6 +163,8 @@ ActiveRecord::Schema.define(version: 20180608153633) do
   add_foreign_key "data_tables", "bots"
   add_foreign_key "invitations", "bots"
   add_foreign_key "invitations", "users", column: "creator_id"
+  add_foreign_key "sessions", "bots"
+  add_foreign_key "sessions", "users"
   add_foreign_key "translations", "behaviours"
   add_foreign_key "variable_assignments", "bots"
 end

--- a/spec/controllers/api/bots_controller_spec.rb
+++ b/spec/controllers/api/bots_controller_spec.rb
@@ -28,6 +28,28 @@ RSpec.describe Api::BotsController, type: :controller do
     end
   end
 
+  describe "preview" do
+    it "previews a new bot" do
+      expect(Backend).to receive(:create_bot) { 'bot preview uuid abc' }
+      post :preview, params: { id: bot.id, access_token: "an access token" }
+      expect(response).to be_success
+      expect(json_body).to eq ({"result"=>"ok", "preview_uuid"=>"bot preview uuid abc"})
+      bot.reload
+      expect(bot.preview_uuid).to eq('bot preview uuid abc')
+    end
+
+    it "previews an existing bot" do
+      another_bot = create(:bot, preview_uuid: 'bot preview uuid bcd', owner: user)
+      expect(Backend).to receive(:update_bot)
+      expect {
+        post :preview, params: { id: another_bot.id, access_token: "an access token" }
+        another_bot.reload
+        expect(response).to be_success
+        expect(json_body).to eq ({"result"=>"ok", "preview_uuid"=> another_bot.preview_uuid})
+      }.not_to change(another_bot, :preview_uuid)
+    end
+  end
+
   describe "create" do
     it "creates a new bot" do
       expect do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,10 @@
 FactoryBot.define do
+  factory :session do
+    user
+    bot
+    sequence(:session_uuid) { |n| "session-uuid-#{n}" }
+  end
+
   factory :user, aliases: [:owner] do
     sequence(:email) { |n| "user-#{n}@example.com" }
   end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Session, type: :model do
+  let!(:user) { create(:user) }
+  let!(:bot) { create(:bot, owner: user) }
+
+  describe "create" do
+    it "creates a session for his owner" do
+      expect do
+        session = create(:session, user: user, bot: bot, session_uuid: 'session uuid abc')
+      end.to change(Session, :count).by(1)
+      expect(bot.get_session(user)).to_not be_nil
+      expect(bot.get_session(user).session_uuid).to eq("session uuid abc")
+    end
+
+    it "creates a session for a collaborator" do
+      collaborator = create(:user)
+      create(:collaborator, bot: bot, user:collaborator)
+      expect do
+        session = create(:session, user: collaborator, bot: bot, session_uuid: "session uuid bcd")
+      end.to change(Session, :count).by(1)
+      expect(bot.get_session(collaborator)).to_not be_nil
+      expect(bot.get_session(collaborator).session_uuid).to eq("session uuid bcd")
+    end
+
+    it "does not create a session for unauthorized" do
+      owner = create(:user)
+      bot = create(:bot, owner: owner)
+      unauthorized = create(:user)
+      expect do
+        session = create(:session, user: unauthorized, bot: bot, session_uuid: 'session uuid abc')
+      end.to raise_error(ActiveRecord::RecordInvalid,"Validation failed: User is not a collaborator")
+      expect(bot.get_session(unauthorized)).to be_nil
+    end
+
+    it "does not create a session whitout an user" do
+      expect do
+        session = create(:session, bot: bot, user:nil)
+      end.to raise_error(ActiveRecord::RecordInvalid,"Validation failed: User must exist, User can't be blank")
+    end
+
+    it "does not create a session whitout a bot" do
+      expect do
+        session = create(:session, bot: nil, user:user)
+      end.to raise_error(ActiveRecord::RecordInvalid,"Validation failed: Bot must exist, Bot can't be blank")
+    end
+
+  end
+end

--- a/spec/services/publish_bot_spec.rb
+++ b/spec/services/publish_bot_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe PublishBot, type: :service do
+
+  it "creates preview bot" do
+    bot = create(:bot, preview_uuid: nil)
+    expect(Backend).to receive(:create_bot) { 'bot preview uuid abc' }
+    preview_uuid = PublishBot.preview(bot, 'an access token')
+    expect(preview_uuid).to eq('bot preview uuid abc')
+    bot.reload
+    expect(bot.preview_uuid).to eq('bot preview uuid abc')
+  end
+
+  it "gets an existing preview bot" do
+    bot = create(:bot, preview_uuid: 'bot preview uuid bcd')
+    expect(Backend).to receive(:update_bot)
+    expect {
+      preview_uuid = PublishBot.preview(bot, 'an access token')
+      bot.reload
+      expect(preview_uuid).to eq('bot preview uuid bcd')
+    }.not_to change(bot, :preview_uuid)
+  end
+
+end


### PR DESCRIPTION
Link ui bots and sessions to their corresponding temporal bots and sessions. It enhances user experiences and avoid undesirable re-creations of bots and sessions on the back-end.

Fixes instedd/aida#143