### PR TITLE
Facebook channel setup updates

### DIFF
--- a/app/javascript/components/BotChannel.jsx
+++ b/app/javascript/components/BotChannel.jsx
@@ -36,18 +36,45 @@ class BotChannelComponent extends Component {
     }
 
     if (channel) {
-      return <SingleColumn>
-        <Title>Setup a Facebook channel</Title>
-        <Headline>
-          In order to setup this channel you first need to
-          create a <a href="https://www.facebook.com/business/products/pages" target="_blank">Facebook page</a> and
-          then <a href="https://developers.facebook.com/docs/messenger-platform/getting-started/app-setup" target="_blank">subscribe a bot</a>.
-        </Headline>
+      let setupFields = <div>
+        <Field label="Page ID" value={channel.config.page_id} onChange={this.updateConfigField("page_id")} helpText="The Page ID under the More info section on your Facebook Page's About tab" />
+        <Field label="Access Token" value={channel.config.access_token} onChange={this.updateConfigField("access_token")} helpText="The Page Access Token you get on the Token Generation section of the Messenger > Settings tab of your Facebook Application" />
+      </div>
 
-        <Field label="Page ID" value={channel.config.page_id} onChange={this.updateConfigField("page_id")} />
-        <Field label="Verify Token" value={channel.config.verify_token} onChange={this.updateConfigField("verify_token")} />
-        <Field label="Access Token" value={channel.config.access_token} onChange={this.updateConfigField("access_token")} />
-      </SingleColumn>
+      if (bot.published) {
+        return <SingleColumn>
+            <Title>Subscribe channel to Aida</Title>
+            <Headline>
+              Finish the channel setup taking your callback URL and verify token to
+              the <a href="https://developers.facebook.com/docs/messenger-platform/getting-started/app-setup" target="_blank">subscribe bot page</a>.
+            </Headline>
+
+            <Field label="Callback URL" defaultValue={`${location.protocol}//${location.host}/callbacks/facebook/`} readOnly />
+            <Field label="Verify Token" value={channel.config.verify_token} onChange={this.updateConfigField("verify_token")} />
+            { /* TODO: replace `<br /><br />` with proper CSS spacing */ }
+            <br /><br />
+            <Title>Facebook channel configuration</Title>
+            <Headline>
+              You can fix your Facebook channel's configuration here in case you've found an error
+            </Headline>
+            {setupFields}
+          </SingleColumn>
+      } else {
+        return <SingleColumn>
+          <Title>Setup a Facebook channel</Title>
+          <Headline>
+            In order to setup this channel you first need
+            to <a href="https://www.facebook.com/business/products/pages" target="_blank">create a Facebook page</a> and
+            then paste your credentials here.
+            Follow <a href="https://developers.facebook.com/docs/messenger-platform/prelaunch-checklist" target="_blank">Facebook publishing requirements</a> to
+            avoid getting your channel banned.<br />
+
+            You will be able to subscribe the bot after you first publish it.
+          </Headline>
+
+          {setupFields}
+        </SingleColumn>
+      }
     } else {
       return <EmptyLoader>Loading channels for {bot.name}</EmptyLoader>
     }

--- a/app/javascript/ui/Field.jsx
+++ b/app/javascript/ui/Field.jsx
@@ -3,7 +3,7 @@ import { TextField } from 'react-md';
 
 export class Field extends Component {
   render() {
-    const {label, value, onChange, id, helpText, leftIcon, placeholder, style, className, resize} = this.props
+    const {label, value, onChange, id, helpText, leftIcon, placeholder, style, className, resize, defaultValue, readOnly} = this.props
 
     return <TextField
       label={label}
@@ -17,6 +17,8 @@ export class Field extends Component {
       placeholder={placeholder}
       style={style}
       resize={resize}
+      defaultValue={defaultValue}
+      readOnly={readOnly || false}
     />
   }
 }

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -20,7 +20,7 @@ class Bot < ApplicationRecord
     bot.name = "Bot #{bot.id}"
 
     bot.channels.create! kind: "facebook", name: "facebook", config: {
-      "page_id" => "", "verify_token" => "", "access_token" => ""
+      "page_id" => "", "verify_token" => SecureRandom.base58, "access_token" => ""
     }
 
     bot.behaviours.create_front_desk!

--- a/spec/models/bot_spec.rb
+++ b/spec/models/bot_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe Bot, type: :model do
     expect(bot).to be_valid
   end
 
+  it "defaults a bot's verify token" do
+    bot = Bot.create_prepared!(user)
+    expect(bot.channels.first.config["verify_token"]).to_not be_empty
+  end
+
   describe "manifest" do
     let!(:bot) { Bot.create_prepared! user }
     let!(:skill) { bot.skills.create_skill! 'keyword_responder' }


### PR DESCRIPTION
Splits channel setup from bot subscription.

On channel setup, users only have to provide Facebook's channel settings - Page ID & access token.

![Channel setup screen](https://user-images.githubusercontent.com/5470539/41494211-8d445d6c-70e6-11e8-83aa-9154c43db3d3.png)

After the bot is published, users see the bot subscription page with the data they need - callback URL & verify token. We default a `verify_token` upon bot creation so the user doesn't have to come up with one - but they still can change it if desired.

Users still can see (and edit) channel settings, in case there was any error while publishing.

![Subscribe channel screen](https://user-images.githubusercontent.com/5470539/41494181-36b8c6b8-70e6-11e8-94de-84c2be98439c.png)

Fixes instedd/aida#17