### PR TITLE
Notifications endpoint & policy enforcements alerts

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -1,0 +1,48 @@
+class Api::NotificationsController < ActionController::Base
+  before_action :set_raven_context
+  rescue_from ActionController::ParameterMissing, with: :render_unprocessable_entity_response
+
+  def create
+    bot = Bot.find_by_notifications_secret(params[:notifications_secret])
+    return render json: {error: "Unknown notification secret"}, status: :unauthorized unless bot
+
+    @notification = bot.notifications.create! notification_params
+
+    if @notification.save
+      render json: {result: :ok}
+    else
+      render json: @notification.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+    def notification_params
+      the_params = params.require(:notification).permit(:type)
+      the_params[:data] = params.require(:notification).fetch(:data, {}).permit!
+      the_params
+    end
+
+    def render_unprocessable_entity_response(exception)
+      render json: 'Invalid notification', status: :unprocessable_entity
+    end
+
+    def set_raven_context
+      if current_user
+        Raven.user_context(
+          id: current_user.id,
+          email: current_user.email,
+          username: current_user.name,
+          ip_address: request.ip,
+        )
+      else
+        Raven.user_context(
+          ip_address: request.ip,
+        )
+      end
+      Raven.extra_context(
+        params: params.to_unsafe_h,
+        url: request.url,
+        version: VersionHelper.version_name,
+      )
+    end
+end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -9,9 +9,18 @@ class Api::NotificationsController < ActionController::Base
     @notification = bot.notifications.create! notification_params
 
     if @notification.save
+      alert_by_email_if_needed
       render json: {result: :ok}
     else
       render json: @notification.errors, status: :unprocessable_entity
+    end
+  end
+
+  def alert_by_email_if_needed
+    mailer = PolicyEnforcementMailer.with(notification: @notification)
+    if @notification.notification_type == 'policy_enforcement'
+      action = @notification.data['action']
+      mailer.bot_blocked.deliver_later if action == 'block'
     end
   end
 

--- a/app/mailers/policy_enforcement_mailer.rb
+++ b/app/mailers/policy_enforcement_mailer.rb
@@ -1,0 +1,16 @@
+class PolicyEnforcementMailer < ApplicationMailer
+  before_action :set_notification_and_bot
+
+  def bot_blocked
+    @reason = @notification.data['reason']
+    mail(to: @bot.owner.email, subject: "Bot #{@bot.name} has been blocked by Policy Enforcement")
+  end
+
+  private
+
+  def set_notification_and_bot
+    @notification = params[:notification]
+    @bot = @notification.bot
+    @bot_url = bot_behaviour_url(@bot.id)
+  end
+end

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -43,6 +43,7 @@ class Bot < ApplicationRecord
     {
       version: "1",
       languages: available_languages,
+      notifications_url: notifications_url,
       front_desk: front_desk.manifest_fragment,
       skills: skills.enabled.map do |skill|
         skill.manifest_fragment
@@ -122,6 +123,10 @@ class Bot < ApplicationRecord
 
   def generate_notifications_secret!
     self.notifications_secret = SecureRandom.hex(40)
+  end
+
+  def notifications_url
+    "#{Settings.base_url}notifications/#{notifications_secret}"
   end
 
   private

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -10,6 +10,7 @@ class Bot < ApplicationRecord
   has_many :collaborating_users, through: :collaborators, source: :user
   has_many :sessions
   has_many :users, through: :sessions
+  has_many :notifications, dependent: :destroy
 
   validate :has_single_front_desk
 

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -28,6 +28,8 @@ class Bot < ApplicationRecord
 
     bot.behaviours.create_front_desk!
 
+    bot.generate_notifications_secret!
+
     bot.save!
     bot
   end
@@ -115,6 +117,10 @@ class Bot < ApplicationRecord
 
   def get_session(user)
     self.sessions.where(user: user).take
+  end
+
+  def generate_notifications_secret!
+    self.notifications_secret = SecureRandom.hex(40)
   end
 
   private

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,4 @@
+class Notification < ApplicationRecord
+  belongs_to :bot
+  alias_attribute :type, :notification_type
+end

--- a/app/views/policy_enforcement_mailer/bot_blocked.html.erb
+++ b/app/views/policy_enforcement_mailer/bot_blocked.html.erb
@@ -1,0 +1,12 @@
+<h1>Your bot <%= @bot.name %> has been <b>blocked by Policy Enforcement</b>.</h1>
+<p>
+  The alleged reason is:
+</p>
+<p>
+  <%= @reason %>
+</p>
+<p>
+  Your bot won't work until you fix this issues and gets reviewed.
+
+  You can <a href="<%= @bot_url %>">edit your bot</a> to fix it.
+</p>

--- a/app/views/policy_enforcement_mailer/bot_blocked.txt.erb
+++ b/app/views/policy_enforcement_mailer/bot_blocked.txt.erb
@@ -1,0 +1,9 @@
+Your bot <%= @bot.name %> has been blocked by Policy Enforcement
+
+The alleged reason is:
+
+<%= @reason %>
+
+Your bot won't work until you fix this issues and gets reviewed.
+
+You can edit your bot at <%= @bot_url %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
 
   root to: 'welcome#index'
   get "/b(/*path)", to: 'welcome#index'
+  get "/b/:bot_id/behaviour", to: 'welcome#index', as: 'bot_behaviour'
   get "/settings(/*path)", to: 'welcome#index'
   get "/invitation/:token", to: 'welcome#index', as: 'invitation'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,5 +79,7 @@ Rails.application.routes.draw do
   get "/settings(/*path)", to: 'welcome#index'
   get "/invitation/:token", to: 'welcome#index', as: 'invitation'
 
+  post '/notifications/:notifications_secret', to: 'api/notifications#create', as: 'notifications_create'
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20180713173426_add_notifications_secret_to_bots.rb
+++ b/db/migrate/20180713173426_add_notifications_secret_to_bots.rb
@@ -1,0 +1,9 @@
+class AddNotificationsSecretToBots < ActiveRecord::Migration[5.1]
+  def change
+    add_column :bots, :notifications_secret, :string
+    Bot.reset_column_information
+    Bot.all.each do |bot|
+      bot.update_attributes!(notifications_secret: SecureRandom.hex(40))
+    end
+  end
+end

--- a/db/migrate/20180713214007_create_notifications.rb
+++ b/db/migrate/20180713214007_create_notifications.rb
@@ -1,0 +1,11 @@
+class CreateNotifications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :notifications do |t|
+      t.references :bot, foreign_key: true
+      t.string :notification_type
+      t.json :data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180706130248) do
+ActiveRecord::Schema.define(version: 20180713173426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20180706130248) do
     t.bigint "owner_id"
     t.string "uuid"
     t.string "preview_uuid"
+    t.string "notifications_secret"
     t.index ["owner_id"], name: "index_bots_on_owner_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180713173426) do
+ActiveRecord::Schema.define(version: 20180713214007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,6 +105,15 @@ ActiveRecord::Schema.define(version: 20180713173426) do
     t.index ["token"], name: "index_invitations_on_token", unique: true
   end
 
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "bot_id"
+    t.string "notification_type"
+    t.json "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bot_id"], name: "index_notifications_on_bot_id"
+  end
+
   create_table "sessions", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "bot_id"
@@ -164,6 +173,7 @@ ActiveRecord::Schema.define(version: 20180713173426) do
   add_foreign_key "data_tables", "bots"
   add_foreign_key "invitations", "bots"
   add_foreign_key "invitations", "users", column: "creator_id"
+  add_foreign_key "notifications", "bots"
   add_foreign_key "sessions", "bots"
   add_foreign_key "sessions", "users"
   add_foreign_key "translations", "behaviours"

--- a/spec/controllers/api/notifications_controller_spec.rb
+++ b/spec/controllers/api/notifications_controller_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Api::NotificationsController, type: :controller do
+  let!(:user) { create(:user) }
+  let!(:bot) { create(:bot, owner: user) }
+
+  let(:policy_enforcement_block_notification) {
+    {
+      type: "policy_enforcement",
+      data: {
+        "action": "block",
+        "reason": "The bot violated our Platform Policies (https://developers.facebook.com/policy/#messengerplatform). Common violations include sending out excessive spammy messages or being non-functional."
+      }
+    }
+  }
+
+  describe "POST #create" do
+    context "with valid params" do
+      it "creates a new Notification by bot secret" do
+        expect {
+          post :create, params: {notifications_secret: bot.notifications_secret, notification: policy_enforcement_block_notification}
+        }.to change(Notification, :count).by(1)
+        expect(response).to be_success
+        expect(Notification.last.notification_type).to eq("policy_enforcement")
+        expect(Notification.last.data.keys).to match_array(["reason", "action"])
+        expect(Notification.last.data['action']).to eq("block")
+      end
+
+      it "creates a new Notification with an unknown type" do
+        expect {
+          post :create, params: {notifications_secret: bot.notifications_secret, notification: { type: 'an-unknown-type', data: {}}}
+        }.to change(Notification, :count).by(1)
+        expect(response).to be_success
+        expect(Notification.last.notification_type).to eq('an-unknown-type')
+        expect(Notification.last.data).to be_empty
+      end
+
+      it "rejects notifications with unknown bot secrets" do
+        expect {
+          post :create, params: {notifications_secret: 'unknown-bot-notifications-secret', notification: policy_enforcement_block_notification}
+        }.not_to change(Notification, :count)
+        expect(response).not_to be_success
+      end
+
+      it "rejects notifications without types" do
+        expect {
+          post :create, params: {notifications_secret: bot.notifications_secret, notification: {}}
+        }.not_to change(Notification, :count)
+        expect(response).not_to be_success
+      end
+    end
+  end
+end

--- a/spec/models/bot_spec.rb
+++ b/spec/models/bot_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Bot, type: :model do
         manifest = bot.manifest
         expect(manifest).to_not be_nil
         expect(manifest[:version]).to eq("1")
-        expect(manifest.keys).to match_array(%i(version languages front_desk skills variables channels))
+        expect(manifest.keys).to match_array(%i(version languages front_desk skills variables channels notifications_url))
       end
 
       it "has a public_keys section if the owner has a key pair" do
@@ -34,6 +34,10 @@ RSpec.describe Bot, type: :model do
       it "has a data_tables section if the bot has tables" do
         create(:data_table, bot: bot)
         expect(bot.manifest.keys).to include(:data_tables)
+      end
+
+      it "has a proper notifications_url" do
+        expect(bot.manifest[:notifications_url]).to eq("http://test.host/notifications/#{bot.notifications_secret}")
       end
     end
 


### PR DESCRIPTION
Adds an endpoint to create bot notifications, and notifies via email about new policy enforcement notifications to bot owners.

The integration hasn't been tested yet - it's hard to simulate a policy_enforcement without an active Facebook channel.

Required for instedd/aida#227